### PR TITLE
Optional start day

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ Don't worry though! If you accidentally pass an argument that isn't the symbol o
     OrderedWeek.start_day
     #=> :monday
 
+In addition to the class-level configuration, `OrderedWeek.new` accepts an optional argument for the start day.
+
+    OrderedWeek.start_day
+    #=> :monday
+    OrderedWeek.new(Date.today)
+    #=> [2014-02-10, 2014-02-11, ... ]
+    OrderedWeek.new(Date.today, :sunday)
+    #=> [2014-02-16, 2014-02-17, ... ]
+
 These objects respond to the following methods
 
     OrderedWeek.new.monday

--- a/lib/ordered_week.rb
+++ b/lib/ordered_week.rb
@@ -6,6 +6,8 @@ class OrderedWeek
 
   @@start_day ||= :monday
 
+  attr_reader :start_day
+
   private_constant :WEEK_DAYS
 
   def self.start_day
@@ -66,10 +68,10 @@ class OrderedWeek
     end
 
     def date_is_start_of_week date
-      date.send("#{@start_day}?")
+      date.send("#{start_day}?")
     end
 
     def start_day_index
-      WEEK_DAYS.index(@start_day)
+      WEEK_DAYS.index(start_day)
     end
 end

--- a/lib/ordered_week.rb
+++ b/lib/ordered_week.rb
@@ -17,7 +17,8 @@ class OrderedWeek
     @@start_day = day
   end
 
-  def initialize includes_date=nil
+  def initialize includes_date = nil, start_day = nil
+    @start_day = default_start_day(start_day)
     @days = build_days(default_date(includes_date))
   end
 
@@ -49,6 +50,10 @@ class OrderedWeek
 
   private
 
+    def default_start_day(day)
+      WEEK_DAYS.include?(day) ? day : @@start_day
+    end
+
     def default_date(date)
       date.respond_to?(:to_date) ? date.to_date : Date.today
     end
@@ -61,10 +66,10 @@ class OrderedWeek
     end
 
     def date_is_start_of_week date
-      date.send( (@@start_day.to_s + ??).to_sym )
+      date.send("#{@start_day}?")
     end
 
     def start_day_index
-      WEEK_DAYS.index(@@start_day)
+      WEEK_DAYS.index(@start_day)
     end
 end

--- a/spec/ordered_week_spec.rb
+++ b/spec/ordered_week_spec.rb
@@ -72,6 +72,16 @@ describe OrderedWeek do
       with_arg.start_date.should eq without_arg.start_date
       with_arg.end_date.should eq without_arg.end_date
     end
+
+    it "should accept an optional start day to override the default" do
+      expect(OrderedWeek.new(Date.today, :thursday).start_date)
+        .to be_thursday
+    end
+
+    it "should use the default start day if the given day is invalid" do
+      expect(OrderedWeek.new(Date.today, :bad).start_date)
+        .to eq(OrderedWeek.new.start_date)
+    end
   end
 
   describe "An instance of", OrderedWeek do

--- a/spec/ordered_week_spec.rb
+++ b/spec/ordered_week_spec.rb
@@ -87,6 +87,17 @@ describe OrderedWeek do
   describe "An instance of", OrderedWeek do
     subject { OrderedWeek.new }
 
+    describe "#start_day" do
+      it "should default to the classes start_day" do
+        expect(OrderedWeek.new.start_day).to eq(OrderedWeek.start_day)
+      end
+
+      it "should return the given start_day (if any)" do
+        expect(OrderedWeek.new(Date.today, :wednesday).start_day)
+          .to eq(:wednesday)
+      end
+    end
+
     describe "#start_date" do
       subject { OrderedWeek.new.start_date }
 


### PR DESCRIPTION
Adds a second argument to OrderedWeek::new, which allows users to optionally pass in a start day. This day will be used as the start day for that instance of OrderedWeek, and will not affect the class configuration. Similar to the class level setter, if no start day is given, or if the given day is invalid, the week will default to the start day set at the class level.