### PR TITLE
Store default start day in a class level instance variable

### DIFF
--- a/lib/ordered_week.rb
+++ b/lib/ordered_week.rb
@@ -3,18 +3,20 @@ class OrderedWeek
 
   VERSION = '0.0.1'
   WEEK_DAYS = [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
+  DEFAULT_START_DAY = :monday
 
-  @@start_day ||= :monday
+  @start_day = DEFAULT_START_DAY
 
   private_constant :WEEK_DAYS
+  private_constant :DEFAULT_START_DAY
 
   def self.start_day
-    @@start_day
+    @start_day
   end
 
   def self.start_day= day
     return false unless WEEK_DAYS.include?(day)
-    @@start_day = day
+    @start_day = day
   end
 
   def initialize includes_date=nil
@@ -49,6 +51,10 @@ class OrderedWeek
 
   private
 
+    def self.inherited(base)
+      base.start_day = DEFAULT_START_DAY
+    end
+
     def default_date(date)
       date.respond_to?(:to_date) ? date.to_date : Date.today
     end
@@ -61,10 +67,10 @@ class OrderedWeek
     end
 
     def date_is_start_of_week date
-      date.send( (@@start_day.to_s + ??).to_sym )
+      date.send( (self.class.start_day.to_s + ??).to_sym )
     end
 
     def start_day_index
-      WEEK_DAYS.index(@@start_day)
+      WEEK_DAYS.index(self.class.start_day)
     end
 end

--- a/spec/ordered_week_spec.rb
+++ b/spec/ordered_week_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe OrderedWeek do
+  let(:default_start_day) { :monday }
+  let(:fancy_week) { Class.new(OrderedWeek) }
+
   describe "::start_day" do
     subject { OrderedWeek.start_day }
 
@@ -11,9 +14,15 @@ describe OrderedWeek do
     it "should return a Symbol" do
       subject.should be_a Symbol
     end
+
+    it 'should be set by default for subclasses' do
+      expect(fancy_week.start_day).to eq(default_start_day)
+    end
   end
 
   describe "::start_day=" do
+    after(:each) { OrderedWeek.start_day = default_start_day }
+
     subject { OrderedWeek.start_day = :sunday }
 
     it "should respond" do
@@ -30,6 +39,16 @@ describe OrderedWeek do
         subject
         OrderedWeek.start_day.should eq day
       end
+
+      it 'should not pollute super-classes' do
+        expect { fancy_week.start_day = day }
+          .not_to change { OrderedWeek.start_day }
+      end
+
+      it 'should not pollute sub-classes' do
+        expect { subject }
+          .not_to change { fancy_week.start_day }
+      end
     end
 
     context "given an invalid day of week" do
@@ -41,6 +60,16 @@ describe OrderedWeek do
         OrderedWeek.start_day.should_not eq day
         subject
         OrderedWeek.start_day.should_not eq day
+      end
+
+      it 'should not pollute super-classes' do
+        expect { fancy_week.start_day = day }
+          .not_to change { OrderedWeek.start_day }
+      end
+
+      it 'should not pollute sub-classes' do
+        expect { subject }
+          .not_to change { fancy_week.start_day }
       end
     end
   end


### PR DESCRIPTION
Previously, a class variable was used to set the start day for
OrderedWeek. Such variables have a tendency to produce unforeseen
effects, especially with inheritance. Replace class variable with class
level instance variable. Add inherited hook to OrderedWeek, which sets
the default start day for a subclass when it inherits from OrderedWeek.
This allows subclasses to manage their own start day, separate from that
of the super class.
